### PR TITLE
FIX: AdditionalHandler not registered in DefaultAuthorizationService

### DIFF
--- a/samples/WebApi OWIN/Controllers/ExampleController.cs
+++ b/samples/WebApi OWIN/Controllers/ExampleController.cs
@@ -11,6 +11,12 @@ namespace WebApi_OWIN.Controllers
         {
             return Json("You are authorized!");
         }
+        [HttpGet]
+        [ResourceAuthorize(Policy = "EmployeeNumber2")]
+        public IHttpActionResult Authorized2()
+        {
+            return Json("You (2) are authorized!");
+        }
 
         [HttpGet]
         [ResourceAuthorize(Policy = ExampleConstants.EmployeeNumber6Policy)]

--- a/samples/WebApi OWIN/EmployeeNumber2Handler.cs
+++ b/samples/WebApi OWIN/EmployeeNumber2Handler.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Owin.Security.Authorization;
+using Microsoft.Owin.Security.Authorization.Infrastructure;
+
+namespace WebApi_OWIN
+{
+    public class EmployeeNumber2Handler : AuthorizationHandler<EmployeeNumber2Requirement>
+    {
+        protected override void Handle(AuthorizationContext context, EmployeeNumber2Requirement requirement)
+        {
+            foreach (var claim in context.User.Claims)
+            {
+                if (string.Equals(claim.Type, ExampleConstants.EmployeeClaimType))
+                {
+                    if (claim.Value == "2")
+                    {
+                        context.Succeed(requirement);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/samples/WebApi OWIN/EmployeeNumber2Requirement.cs
+++ b/samples/WebApi OWIN/EmployeeNumber2Requirement.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Owin.Security.Authorization;
+
+namespace WebApi_OWIN
+{
+    public class EmployeeNumber2Requirement : IAuthorizationRequirement
+    {
+
+    }
+}

--- a/samples/WebApi OWIN/ExampleConstants.cs
+++ b/samples/WebApi OWIN/ExampleConstants.cs
@@ -5,5 +5,6 @@
         public const string EmployeeClaimType = "EmployeeNumber";
         public const string EmployeeOnlyPolicy = "EmployeeOnly";
         public const string EmployeeNumber6Policy = "EmployeeNumber6";
+        public const string EmployeeNumber2Policy = "EmployeeNumber2";
     }
 }

--- a/samples/WebApi OWIN/Startup.cs
+++ b/samples/WebApi OWIN/Startup.cs
@@ -28,6 +28,8 @@ namespace WebApi_OWIN
             {
                 options.AddPolicy(ExampleConstants.EmployeeOnlyPolicy, policyBuilder => policyBuilder.RequireClaim(ExampleConstants.EmployeeClaimType));
                 options.AddPolicy(ExampleConstants.EmployeeNumber6Policy, policyBuilder => policyBuilder.RequireClaim(ExampleConstants.EmployeeClaimType, "6"));
+                options.AddPolicy(ExampleConstants.EmployeeNumber2Policy, policyBuilder => policyBuilder.AddRequirements(new EmployeeNumber2Requirement()));
+                options.Dependencies.AdditionalHandlers.Add(new EmployeeNumber2Handler());
             });
 
             app.UseWebApi(config);

--- a/samples/WebApi OWIN/WebApi OWIN.csproj
+++ b/samples/WebApi OWIN/WebApi OWIN.csproj
@@ -60,14 +60,6 @@
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Authorization, Version=0.1.0.39, Culture=neutral, PublicKeyToken=ba8e29017989cc66, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Authorization.0.1.0.39-beta\lib\net452\Microsoft.Owin.Security.Authorization.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Security.Authorization.WebApi, Version=0.1.0.39, Culture=neutral, PublicKeyToken=ba8e29017989cc66, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Authorization.WebApi.0.1.0.39-beta\lib\net452\Microsoft.Owin.Security.Authorization.WebApi.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -133,11 +125,22 @@
   <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\ExampleController.cs" />
+    <Compile Include="EmployeeNumber2Handler.cs" />
+    <Compile Include="EmployeeNumber2Requirement.cs" />
     <Compile Include="ExampleConstants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.Security.Authorization.WebApi\Microsoft.Owin.Security.Authorization.WebApi.csproj">
+      <Project>{b21e8782-d3d8-4329-bd92-2dba581f1c9b}</Project>
+      <Name>Microsoft.Owin.Security.Authorization.WebApi</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.Security.Authorization\Microsoft.Owin.Security.Authorization.csproj">
+      <Project>{a74dc534-bd34-419b-9fd4-dabcbae53a46}</Project>
+      <Name>Microsoft.Owin.Security.Authorization</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/Microsoft.Owin.Security.Authorization/Infrastructure/AppBuilderExtensions.cs
+++ b/src/Microsoft.Owin.Security.Authorization/Infrastructure/AppBuilderExtensions.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Owin.Security.Authorization.Infrastructure
             if (options.Dependencies.Service == null)
             {
                 var policyProvider = new DefaultAuthorizationPolicyProvider(options);
-                var handlers = new List<IAuthorizationHandler>() { new PassThroughAuthorizationHandler() };
+                var handlers = new List<IAuthorizationHandler>(options.Dependencies.AdditionalHandlers)
+                {
+                    new PassThroughAuthorizationHandler()
+                };
                 var logger = options.Dependencies.LoggerFactory.Create(options.GetType().Name);
                 options.Dependencies.Service = new DefaultAuthorizationService(policyProvider, handlers, logger);
             }


### PR DESCRIPTION
splitting up IAuthorizationRequirement and AuthorizationHandler, it is necessary to register itas AdditionalHandler -> this AdditionalHandler is not considered in DefaultAuthorizationService

updated WebApi OWIN sample to demonstrate

BTW: the main reason for this split is to allow dependency injection in the AuthorizationHandler, so I'm not sure if this AdditionalHandler mechanism in the backport is the best strategy...
