### PR TITLE
MVC Context in Handler

### DIFF
--- a/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
+++ b/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class ResourceAuthorizeAttribute : AuthorizeAttribute, IAuthorizeData
     {
-        private const string s_controllerKey = "Owin.AuthorizationController";
+        private const string s_authorizationContextKey = "Owin.AuthorizationContext";
 
         /// <inheritdoc />
         public string Policy { get; set; }
@@ -29,9 +29,9 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
                 throw new ArgumentNullException(nameof(filterContext));
             }
 
-            if (!filterContext.HttpContext.Items.Contains(s_controllerKey))
+            if (!filterContext.HttpContext.Items.Contains(s_authorizationContextKey))
             {
-                filterContext.HttpContext.Items.Add(s_controllerKey, filterContext.Controller);
+                filterContext.HttpContext.Items.Add(s_authorizationContextKey, filterContext.Controller);
             }
 
             base.OnAuthorization(filterContext);
@@ -45,11 +45,12 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            var controller = httpContext.Items[s_controllerKey] as IAuthorizationController;
+            var filterContext = (System.Web.Mvc.AuthorizationContext)httpContext.Items[s_authorizationContextKey];
+            var controller = filterContext.Controller as IAuthorizationController;
             var user = (ClaimsPrincipal)httpContext.User;
             var contextAccessor = new HttpContextBaseOwinContextAccessor(httpContext);
             var authorizationHelper = new AuthorizationHelper(contextAccessor);
-            return authorizationHelper.IsAuthorizedAsync(controller, user, this).Result;
+            return authorizationHelper.IsAuthorizedAsync(controller, user, this, filterContext).Result;
         }
     }
 }

--- a/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
+++ b/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
 
             if (!filterContext.HttpContext.Items.Contains(s_authorizationContextKey))
             {
-                filterContext.HttpContext.Items.Add(s_authorizationContextKey, filterContext.Controller);
+                filterContext.HttpContext.Items.Add(s_authorizationContextKey, filterContext);
             }
 
             base.OnAuthorization(filterContext);

--- a/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
+++ b/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            var filterContext = (System.Web.Mvc.AuthorizationContext)httpContext.Items[s_authorizationContextKey];
+            var filterContext = httpContext.Items[s_authorizationContextKey] as System.Web.Mvc.AuthorizationContext;
             var controller = filterContext.Controller as IAuthorizationController;
             var user = (ClaimsPrincipal)httpContext.User;
             var contextAccessor = new HttpContextBaseOwinContextAccessor(httpContext);

--- a/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
+++ b/src/Microsoft.Owin.Security.Authorization.Mvc/ResourceAuthorizeAttribute.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Owin.Security.Authorization.Mvc
             }
 
             var filterContext = httpContext.Items[s_authorizationContextKey] as System.Web.Mvc.AuthorizationContext;
-            var controller = filterContext.Controller as IAuthorizationController;
+            var controller = filterContext?.Controller as IAuthorizationController;
             var user = (ClaimsPrincipal)httpContext.User;
             var contextAccessor = new HttpContextBaseOwinContextAccessor(httpContext);
             var authorizationHelper = new AuthorizationHelper(contextAccessor);

--- a/src/Microsoft.Owin.Security.Authorization.WebApi/ResourceAuthorizeAttribute.cs
+++ b/src/Microsoft.Owin.Security.Authorization.WebApi/ResourceAuthorizeAttribute.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Owin.Security.Authorization.WebApi
             var user = (ClaimsPrincipal)actionContext.RequestContext.Principal;
             var owinAccessor = new HttpRequestMessageOwinContextAccessor(actionContext.Request);
             var helper = new AuthorizationHelper(owinAccessor);
-            return helper.IsAuthorizedAsync(controller, user, this).Result;
+            return helper.IsAuthorizedAsync(controller, user, this, actionContext).Result;
         }
     }
 }

--- a/src/Microsoft.Owin.Security.Authorization/AuthorizationHelper.cs
+++ b/src/Microsoft.Owin.Security.Authorization/AuthorizationHelper.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Owin.Security.Authorization
         /// <param name="controller">The controller from which <see cref="AuthorizationOptions"/> may be obtained.</param>
         /// <param name="user">The user to evaluate the authorize data against.</param>
         /// <param name="authorizeAttribute">The <see cref="IAuthorizeData"/> to evaluate.</param>
+        /// <param name="resource">The resource to evaluate the authorize data against.</param>
         /// <returns>
         /// A flag indicating whether authorization has succeeded.
         /// This value is <value>true</value> when the <paramref name="user"/> fulfills the <paramref name="authorizeAttribute"/>; otherwise <value>false</value>.
@@ -40,7 +41,7 @@ namespace Microsoft.Owin.Security.Authorization
         /// <remarks>
         /// If <paramref name="controller"/> is not null, it will be used to find <see cref="AuthorizationOptions"/> instead of the current <see cref="IOwinContext"/>.
         /// </remarks>
-        public async Task<bool> IsAuthorizedAsync(IAuthorizationController controller, ClaimsPrincipal user, IAuthorizeData authorizeAttribute)
+        public async Task<bool> IsAuthorizedAsync(IAuthorizationController controller, ClaimsPrincipal user, IAuthorizeData authorizeAttribute, object resource = null)
         {
             if (user == null)
             {
@@ -74,7 +75,7 @@ namespace Microsoft.Owin.Security.Authorization
             }
 
             var policy = await AuthorizationPolicy.CombineAsync(policyProvider, new[] { authorizeAttribute });
-            return await authorizationService.AuthorizeAsync(user, policy);
+            return await authorizationService.AuthorizeAsync(user, resource, policy);
         }
 
         private AuthorizationOptions ResolveAuthorizationOptions(IAuthorizationController controller)

--- a/src/Microsoft.Owin.Security.Authorization/IResourceAuthorizationHelper.cs
+++ b/src/Microsoft.Owin.Security.Authorization/IResourceAuthorizationHelper.cs
@@ -14,10 +14,11 @@ namespace Microsoft.Owin.Security.Authorization
         /// <param name="controller">The controller from which <see cref="AuthorizationOptions"/> may be obtained.</param>
         /// <param name="user">The user to evaluate the authorize data against.</param>
         /// <param name="authorizeAttribute">The <see cref="IAuthorizeData"/> to evaluate.</param>
+        /// <param name="resource">The resource to evaluate the authorize data against.</param>
         /// <returns>
         /// A flag indicating whether authorization has succeeded.
         /// This value is <value>true</value> when the <paramref name="user"/> fulfills the <paramref name="authorizeAttribute"/>; otherwise <value>false</value>.
         /// </returns>
-        Task<bool> IsAuthorizedAsync(IAuthorizationController controller, ClaimsPrincipal user, IAuthorizeData authorizeAttribute);
+        Task<bool> IsAuthorizedAsync(IAuthorizationController controller, ClaimsPrincipal user, IAuthorizeData authorizeAttribute, object resource = null);
     }
 }


### PR DESCRIPTION
This adds the filterContext or actionContext for MVC and WebApi respectively as a resource in the handler when using ResourceAuthorize.